### PR TITLE
Fix sympy issue (New version have no 'numbers' module)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ seaborn>=0.9.0
 tqdm>=4.25.0
 typing>=3.6.6
 ipywidgets
-sympy>=1.5.1
+sympy==1.6
 simpy>=4.0.1
 z3-solver>=4.8.9


### PR DESCRIPTION
New versions have no 'numbers' module.